### PR TITLE
[NodeSearchBundle] fix use_match_query_for_title

### DIFF
--- a/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
+++ b/src/Kunstmaan/NodeSearchBundle/Search/NodeSearcher.php
@@ -87,7 +87,7 @@ class NodeSearcher extends AbstractElasticaSearcher
             $elasticaQueryTitle = new \Elastica\Query\Match();
             $elasticaQueryTitle
               ->setFieldQuery('title', $query)
-              ->setFieldBoost(2.0)
+              ->setFieldBoost('title', 2.0)
               ->setFieldMinimumShouldMatch('title', '80%');
         } else {
             $elasticaQueryTitle = new \Elastica\Query\QueryString();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 

When using `use_match_query_for_title: true`, exception occurs on search.